### PR TITLE
將所有 env() 改為 config()

### DIFF
--- a/src/Charge.php
+++ b/src/Charge.php
@@ -10,7 +10,7 @@ class Charge
 
     public function __construct(Helpers $helpers)
     {
-        if (env('APP_ENV') === 'production') {
+        if (config('app.env') === 'production') {
             $this->apiUrl['MPG_API']
                 = 'https://core.spgateway.com/MPG/mpg_gateway';
             $this->apiUrl['QUERY_TRADE_INFO_API']

--- a/src/MPG.php
+++ b/src/MPG.php
@@ -15,7 +15,7 @@ class MPG
     public function __construct()
     {
         $this->apiUrl = [];
-        if (env('APP_ENV') === 'production') {
+        if (config('app.env') === 'production') {
             $this->apiUrl['MPG_API']
                 = 'https://core.spgateway.com/MPG/mpg_gateway';
             $this->apiUrl['QUERY_TRADE_INFO_API']
@@ -126,7 +126,7 @@ class MPG
         $tradeSha = $this->createMpgSHA256Encrypt($tradeInfo);
 
         $this->postDataEncrypted = [
-            'MerchantID' => env('SPGATEWAY_MERCHANT_ID'),
+            'MerchantID' => config('spgateway.mpg.MerchantID'),
             'TradeInfo'  => $tradeInfo,
             'TradeSha'   => $tradeSha,
             'Version'    => '1.4',

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -17,7 +17,7 @@ class Receipt
 
     public function __construct()
     {
-        if (env('APP_ENV') === 'production') {
+        if (config('app.env') === 'production') {
             $this->apiUrl['CREATE_RECEIPT_API']
                 = 'https://inv.pay2go.com/API/invoice_issue';
             $this->apiUrl['INVALID_RECEIPT_API']

--- a/src/Refund.php
+++ b/src/Refund.php
@@ -15,7 +15,7 @@ class Refund
     public function __construct()
     {
         $this->apiUrl = [];
-        if (env('APP_ENV') === 'production') {
+        if (config('app.env') === 'production') {
             $this->apiUrl['CREDIT_CARD_CANCEL_API']
                 = 'https://core.spgateway.com/API/CreditCard/Cancel';
             $this->apiUrl['CREDIT_CARD_REFUND_API']

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -13,7 +13,7 @@ class Transfer
 
     public function __construct()
     {
-        if (env('APP_ENV') === 'production') {
+        if (config('app.env') === 'production') {
             $this->apiUrl['CHARGE_INSTRUCT_API']
                 = 'https://core.spgateway.com/API/ChargeInstruct';
         } else {


### PR DESCRIPTION
解決 `php artisan config:cache` 會讀不到 env() 內商店代號的問題