### PR TITLE
支援 laravel 8 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Laravel Spgateway是一個開源的 [智付通](https://www.spgateway.com/) 非�
 
 ## 要求
 
-1. PHP >= 7
-2. Laravel >= 5
+1. PHP >= 7.2.5
+2. Laravel >= 7
 3. Composer
 
 ## 安裝

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
         "email": "leo@hourmasters.com"
     }],
     "require": {
-        "php": ">=7",
-        "guzzlehttp/guzzle": "~6.0"
+        "php": ">=7.2",
+        "laravel/framework": "^6|^7|^8",
+        "guzzlehttp/guzzle": "^6.5.5|^7.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "email": "leo@hourmasters.com"
     }],
     "require": {
-        "php": ">=7.2",
-        "laravel/framework": "^6|^7|^8",
+        "php": ">=7.2.5",
+        "laravel/framework": "^7|^8",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1"
     },
     "autoload": {

--- a/resources/views/send-order.blade.php
+++ b/resources/views/send-order.blade.php
@@ -5,12 +5,12 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>正在導向到智付通...</title>
+    <title>正在導向到藍新金流...</title>
 
     <style>
         body {
             padding: 1em;
-            color: #F5A223;
+            color: #0B0B61;
             text-align: center;
             width: 80%;
             margin: 0 auto;
@@ -48,7 +48,7 @@
     @endforeach
 </form>
 
-<h1>正在導向到智付通...</h1>
+<h1>正在導向到藍新金流...</h1>
 <div class="loader loader--style3" title="2">
     <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
          x="0px" y="0px"


### PR DESCRIPTION
laravel 8 在安裝時會出現 guzzlehttp/guzzle 的版本錯誤。因為 laravel 8 開始，直接使用 7.0.1 版，不再使用 6.x 了。
這個更新會讓這套件支援 laravel 7 以上。如果要使用的話，可以用新的版本發行，以有別於現在 laravel 5 到 7 的支援。

另外，預設的導向智付通的頁面，改為導向藍新金流。